### PR TITLE
Increase maximum frequency in web interface.

### DIFF
--- a/data_embed/index.html
+++ b/data_embed/index.html
@@ -51,7 +51,7 @@
                 <div class="grid-container halves">
                     <div>
                         <label for="lora_freq">Frequency [MHz]</label>
-                        <input name="lora_freq" id="lora_freq" type="number" min="433.000" max="450.000" step="0.001" title="LoRa center frequency between 433.001 and 450.000"> 
+                        <input name="lora_freq" id="lora_freq" type="number" min="433.000" max="928.000" step="0.001" title="LoRa center frequency between 433.001 and 928.000"> 
                     </div>
                     <div>
                         <label for="lora_speed">Speed [baud]</label>


### PR DESCRIPTION
US LoRa frequencies can go up to 928 MHz:
- https://www.rfwireless-world.com/Tutorials/LoRa-channels-list.html
- https://lora.readthedocs.io/en/latest/#rules-and-regulations

Some T-Beams are sold on this frequency.

Mentioned previously in https://github.com/SQ9MDD/TTGO-T-Beam-LoRa-APRS/issues/44.

