### PR TITLE
Clean up telemetry and add option(s) to www interface (TTGO T-beam v.1.0 )

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ After connection with APRX based DIGI it can be used as KISS-TNC
 * ((AUT TX)) - information about sending automatic positioning frame when GPS is turned off
 * ((KISSTX)) - information about sending the frame sent by KISS
 * ((WEB TX)) - sending frame as requested via HTTP
+* ((TEL TX)) - information about sending telemetry
 
 ## How to binary first flash readme... (thanx SP6VWX)
 * Download the appropriate binary file for your board from: https://github.com/SQ9MDD/TTGO-T-Beam-LoRa-APRS/releases

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ After connection with APRX based DIGI it can be used as KISS-TNC
 * In the left column click on the ANT-shaped icon, choose your board and click on "Upload". COM port should be detected automatically Wait for procedure to finish and keep reading
 
 ## Configuring parameters
-Wait for the board to reboot, connect to "N0CALL AP" WiFi network, password is: xxxxxxxxxx (10 times "x") and point your browser to "192.168.4.1". Hover your mouse to textboxes to get useful hints.
+Wait for the board to reboot, connect to "N0CALL AP" WiFi network, password is: xxxxxxxxxx (10 times "x") and point your browser to "http://192.168.4.1" (http, not http*s*). Hover your mouse to textboxes to get useful hints.
 
 ### WiFi Settings
 you can scan for local SSID or manually type in name and password

--- a/data_embed/index.html
+++ b/data_embed/index.html
@@ -101,13 +101,25 @@
                         <label for="aprs_batt">Show Battery</label>
                         <input name="aprs_batt" id="aprs_batt" type="checkbox" value="1" title=" show battery voltage after personal comment">
                     </div>
+                    </div>
+                    <div class="grid-container full">
+                        <h5 class="u-full-width">Telemetry Settings</h5>
+                    </div>
+                    <div class="grid-container quarters">
                     <div>
                         <label for="tnc_tel">Enable Self Telemetry</label>
-                        <input name="tnc_tel" id="tnc_tel" type="checkbox" value="1" title=" send self telemetry data">
+                        <input name="tnc_tel" id="tnc_tel" type="checkbox" value="1" title="send self telemetry data">
                     </div>
                     <div>
                         <label for="tnc_tel_int">Self Telemetry Interval [s]</label>
                         <input name="tnc_tel_int" id="tnc_tel_int" type="number" min="10" title="time between sending telemetry if Enable Self Telemetry option is selected ">
+                    </div>
+                    <div>
+                        <label for="tnc_tel_mic">Self Telemetry Sequence</label>
+                        <select id="tnc_tel_mic" name="tnc_tel_mic" title="self telemetry sequence type (numeric supported by aprs.fi and aprsdirect.com)">
+                            <option value="0">Numeric</option>
+                            <option value="1">MIC</option>
+                        </select>
                     </div>
                 </div>
                 <div class="grid-container full">

--- a/data_embed/index.html
+++ b/data_embed/index.html
@@ -97,6 +97,10 @@
                         <label for="aprs_batt">Show Battery</label>
                         <input name="aprs_batt" id="aprs_batt" type="checkbox" value="1" title=" show battery voltage after personal comment">
                     </div>
+                    <div>
+                        <label for="aprs_self_tel">Enable Self Telemetry</label>
+                        <input name="aprs_self_tel" id="aprs_self_tel" type="checkbox" value="1" title=" send self telemetry data">
+                    </div>
                 </div>
                 <div class="grid-container full">
                     <h5 class="u-full-width">Fixed Beaconing Settings</h5>

--- a/data_embed/index.html
+++ b/data_embed/index.html
@@ -98,8 +98,12 @@
                         <input name="aprs_batt" id="aprs_batt" type="checkbox" value="1" title=" show battery voltage after personal comment">
                     </div>
                     <div>
-                        <label for="aprs_self_tel">Enable Self Telemetry</label>
-                        <input name="aprs_self_tel" id="aprs_self_tel" type="checkbox" value="1" title=" send self telemetry data">
+                        <label for="tnc_tel">Enable Self Telemetry</label>
+                        <input name="tnc_tel" id="tnc_tel" type="checkbox" value="1" title=" send self telemetry data">
+                    </div>
+                    <div>
+                        <label for="tnc_tel_int">Self Telemetry Interval [s]</label>
+                        <input name="tnc_tel_int" id="tnc_tel_int" type="number" min="10" title="time between sending telemetry if Enable Self Telemetry option is selected ">
                     </div>
                 </div>
                 <div class="grid-container full">

--- a/include/preference_storage.h
+++ b/include/preference_storage.h
@@ -7,7 +7,7 @@
 #define ENABLE_PREFERENCES
 extern Preferences preferences;
 
-// MAX 15 chars for preferenece key!!!
+// MAX 15 chars for preference key!!!
 static const char *const PREF_WIFI_SSID = "wifi_ssid";
 static const char *const PREF_WIFI_PASSWORD = "wifi_password";
 // LoRa settings
@@ -35,6 +35,8 @@ static const char *const PREF_APRS_FIXED_BEACON_PRESET = "aprs_fixed_beac";
 static const char *const PREF_APRS_FIXED_BEACON_PRESET_INIT = "aprs_fix_b_init";
 static const char *const PREF_APRS_FIXED_BEACON_INTERVAL_PRESET = "aprs_fb_interv";
 static const char *const PREF_APRS_FIXED_BEACON_INTERVAL_PRESET_INIT = "aprs_fb_in_init";
+static const char *const PREF_ENABLE_TNC_SELF_TELEMETRY = "aprs_self_tel";
+static const char *const PREF_ENABLE_TNC_SELF_TELEMETRY_INIT = "aprs_self_tel_i";
 // SMART BEACONING
 static const char *const PREF_APRS_SB_MIN_INTERVAL_PRESET = "sb_min_interv";
 static const char *const PREF_APRS_SB_MIN_INTERVAL_PRESET_INIT = "sb_min_interv_i";

--- a/include/preference_storage.h
+++ b/include/preference_storage.h
@@ -35,8 +35,10 @@ static const char *const PREF_APRS_FIXED_BEACON_PRESET = "aprs_fixed_beac";
 static const char *const PREF_APRS_FIXED_BEACON_PRESET_INIT = "aprs_fix_b_init";
 static const char *const PREF_APRS_FIXED_BEACON_INTERVAL_PRESET = "aprs_fb_interv";
 static const char *const PREF_APRS_FIXED_BEACON_INTERVAL_PRESET_INIT = "aprs_fb_in_init";
-static const char *const PREF_ENABLE_TNC_SELF_TELEMETRY = "aprs_self_tel";
-static const char *const PREF_ENABLE_TNC_SELF_TELEMETRY_INIT = "aprs_self_tel_i";
+static const char *const PREF_ENABLE_TNC_SELF_TELEMETRY = "tnc_tel";
+static const char *const PREF_ENABLE_TNC_SELF_TELEMETRY_INIT = "tnc_tel_i";
+static const char *const PREF_TNC_SELF_TELEMETRY_INTERVAL = "tnc_tel_int";
+static const char *const PREF_TNC_SELF_TELEMETRY_INTERVAL_INIT = "tnc_tel_int_i";
 // SMART BEACONING
 static const char *const PREF_APRS_SB_MIN_INTERVAL_PRESET = "sb_min_interv";
 static const char *const PREF_APRS_SB_MIN_INTERVAL_PRESET_INIT = "sb_min_interv_i";

--- a/include/preference_storage.h
+++ b/include/preference_storage.h
@@ -39,6 +39,8 @@ static const char *const PREF_ENABLE_TNC_SELF_TELEMETRY = "tnc_tel";
 static const char *const PREF_ENABLE_TNC_SELF_TELEMETRY_INIT = "tnc_tel_i";
 static const char *const PREF_TNC_SELF_TELEMETRY_INTERVAL = "tnc_tel_int";
 static const char *const PREF_TNC_SELF_TELEMETRY_INTERVAL_INIT = "tnc_tel_int_i";
+static const char *const PREF_TNC_SELF_TELEMETRY_SEQ = "tnc_tel_seq";
+static const char *const PREF_TNC_SELF_TELEMETRY_SEQ_INIT = "tnc_tel_seq_i";
 // SMART BEACONING
 static const char *const PREF_APRS_SB_MIN_INTERVAL_PRESET = "sb_min_interv";
 static const char *const PREF_APRS_SB_MIN_INTERVAL_PRESET_INIT = "sb_min_interv_i";

--- a/include/preference_storage.h
+++ b/include/preference_storage.h
@@ -41,6 +41,8 @@ static const char *const PREF_TNC_SELF_TELEMETRY_INTERVAL = "tnc_tel_int";
 static const char *const PREF_TNC_SELF_TELEMETRY_INTERVAL_INIT = "tnc_tel_int_i";
 static const char *const PREF_TNC_SELF_TELEMETRY_SEQ = "tnc_tel_seq";
 static const char *const PREF_TNC_SELF_TELEMETRY_SEQ_INIT = "tnc_tel_seq_i";
+static const char *const PREF_TNC_SELF_TELEMETRY_MIC = "tnc_tel_mic";
+static const char *const PREF_TNC_SELF_TELEMETRY_MIC_INIT = "tnc_tel_mic_i";
 // SMART BEACONING
 static const char *const PREF_APRS_SB_MIN_INTERVAL_PRESET = "sb_min_interv";
 static const char *const PREF_APRS_SB_MIN_INTERVAL_PRESET_INIT = "sb_min_interv_i";

--- a/platformio.ini
+++ b/platformio.ini
@@ -52,6 +52,7 @@ build_flags =
 			-D 'MAX_TIME_TO_NEXT_TX=120000L'	; can be set from www interfeace
 			-D 'FIX_BEACON_INTERVAL=1800000L'	; can be set from www interfeace
 			-D 'NETWORK_GPS_PORT=10110'			; GPS NMEA Port
+			-D 'ENABLE_TNC_SELF_TELEMETRY'		; send telemetry data about device
 
 [env:ttgo-t-beam-v1.0]
 platform = espressif32 @ 3.0.0

--- a/platformio.ini
+++ b/platformio.ini
@@ -53,7 +53,8 @@ build_flags =
 			-D 'FIX_BEACON_INTERVAL=1800000L'	; can be set from www interface
 			-D 'NETWORK_GPS_PORT=10110'			; GPS NMEA Port
 			-D 'ENABLE_TNC_SELF_TELEMETRY'		; can be set from www interface
-			-D 'TNC_SELF_TELEMETRY_INTERVAL=60L' ; telemetry interval (milliseconds)
+			-D 'TNC_SELF_TELEMETRY_INTERVAL=3600L' ; can be set from www interface (seconds)
+			-D 'TNC_SELF_TELEMETRY_SEQ=0L'
 
 [env:ttgo-t-beam-v1.0]
 platform = espressif32 @ 3.0.0

--- a/platformio.ini
+++ b/platformio.ini
@@ -54,7 +54,6 @@ build_flags =
 			-D 'NETWORK_GPS_PORT=10110'			; GPS NMEA Port
 			-D 'ENABLE_TNC_SELF_TELEMETRY'		; can be set from www interface
 			-D 'TNC_SELF_TELEMETRY_INTERVAL=3600L' ; can be set from www interface (seconds)
-		;	-D 'TNC_SELF_TELEMETRY_SEQ=0L'		; start number for telemetry sequence
 			-D 'SHOW_OLED_TIME=15000'			; OLED Timeout
 
 [env:ttgo-t-beam-v1.0]

--- a/platformio.ini
+++ b/platformio.ini
@@ -54,7 +54,7 @@ build_flags =
 			-D 'NETWORK_GPS_PORT=10110'			; GPS NMEA Port
 			-D 'ENABLE_TNC_SELF_TELEMETRY'		; can be set from www interface
 			-D 'TNC_SELF_TELEMETRY_INTERVAL=3600L' ; can be set from www interface (seconds)
-			-D 'TNC_SELF_TELEMETRY_SEQ=0L'		; start number for telemetry sequence
+		;	-D 'TNC_SELF_TELEMETRY_SEQ=0L'		; start number for telemetry sequence
 			-D 'SHOW_OLED_TIME=15000'			; OLED Timeout
 
 [env:ttgo-t-beam-v1.0]

--- a/platformio.ini
+++ b/platformio.ini
@@ -52,8 +52,8 @@ build_flags =
 			-D 'MAX_TIME_TO_NEXT_TX=120000L'	; can be set from www interface
 			-D 'FIX_BEACON_INTERVAL=1800000L'	; can be set from www interface
 			-D 'NETWORK_GPS_PORT=10110'			; GPS NMEA Port
-			-D 'ENABLE_TNC_SELF_TELEMETRY'		; send telemetry data about device
-			-D 'TNC_SELF_TELEMETRY_INTERVAL=60000L' ; telemetry interval (milliseconds)
+			-D 'ENABLE_TNC_SELF_TELEMETRY'		; can be set from www interface
+			-D 'TNC_SELF_TELEMETRY_INTERVAL=60L' ; telemetry interval (milliseconds)
 
 [env:ttgo-t-beam-v1.0]
 platform = espressif32 @ 3.0.0

--- a/platformio.ini
+++ b/platformio.ini
@@ -54,7 +54,7 @@ build_flags =
 			-D 'NETWORK_GPS_PORT=10110'			; GPS NMEA Port
 			-D 'ENABLE_TNC_SELF_TELEMETRY'		; can be set from www interface
 			-D 'TNC_SELF_TELEMETRY_INTERVAL=3600L' ; can be set from www interface (seconds)
-			-D 'TNC_SELF_TELEMETRY_SEQ=0L'
+			-D 'TNC_SELF_TELEMETRY_SEQ=0L'		; start number for telemetry sequence
 			-D 'SHOW_OLED_TIME=15000'			; OLED Timeout
 
 [env:ttgo-t-beam-v1.0]

--- a/platformio.ini
+++ b/platformio.ini
@@ -31,29 +31,29 @@ lib_deps =
 build_flags =
 			-Wl,--gc-sections,--relax
 			-D 'KISS_PROTOCOL'					; leave enabled
-			-D 'CALLSIGN="N0CALL-0"'			; can be set from www interfeace
-			-D 'DIGI_PATH="WIDE1-1"'			; can be set from www interfeace
-			-D 'FIXED_BEACON_EN'				; can be set from www interfeace
-			-D 'LATIDUDE_PRESET="0000.00N"'		; can be set from www interfeace
-			-D 'LONGITUDE_PRESET="00000.00E"'	; can be set from www interfeace
-			-D 'APRS_SYMBOL_TABLE="/"'			; can be set from www interfeace
-			-D 'APRS_SYMBOL="["'				; can be set from www interfeace
-			-D 'MY_COMMENT="Lora Tracker"'		; can be set from www interfeace
-			-D 'SHOW_ALT'						; can be set from www interfeace
-			-D 'SHOW_BATT'						; can be set from www interfeace
-			-D 'SHOW_RX_PACKET'					; can be set from www interfeace
-			-D 'SHOW_RX_TIME=10000' 			; can be set from www interfeace
+			-D 'CALLSIGN="N0CALL-0"'			; can be set from www interface
+			-D 'DIGI_PATH="WIDE1-1"'			; can be set from www interface
+			-D 'FIXED_BEACON_EN'				; can be set from www interface
+			-D 'LATIDUDE_PRESET="0000.00N"'		; can be set from www interface
+			-D 'LONGITUDE_PRESET="00000.00E"'	; can be set from www interface
+			-D 'APRS_SYMBOL_TABLE="/"'			; can be set from www interface
+			-D 'APRS_SYMBOL="["'				; can be set from www interface
+			-D 'MY_COMMENT="Lora Tracker"'		; can be set from www interface
+			-D 'SHOW_ALT'						; can be set from www interface
+			-D 'SHOW_BATT'						; can be set from www interface
+			-D 'SHOW_RX_PACKET'					; can be set from www interface
+			-D 'SHOW_RX_TIME=10000' 			; can be set from www interface
 			-D 'TXFREQ=433.775'					; set operating frequency
 			-D 'SPEED_1200'						; comment out to set 300baud
 			-D 'TXdbmW=23'						; set power
-			-D 'ENABLE_OLED'					; can be set from www interfeace
-			-D 'ENABLE_LED_SIGNALING'			; can be set from www interfeace
+			-D 'ENABLE_OLED'					; can be set from www interface
+			-D 'ENABLE_LED_SIGNALING'			; can be set from www interface
 			-D 'NETWORK_TNC_PORT=8001'			; default KISS TCP port
-			-D 'MAX_TIME_TO_NEXT_TX=120000L'	; can be set from www interfeace
-			-D 'FIX_BEACON_INTERVAL=1800000L'	; can be set from www interfeace
+			-D 'MAX_TIME_TO_NEXT_TX=120000L'	; can be set from www interface
+			-D 'FIX_BEACON_INTERVAL=1800000L'	; can be set from www interface
 			-D 'NETWORK_GPS_PORT=10110'			; GPS NMEA Port
 			-D 'ENABLE_TNC_SELF_TELEMETRY'		; send telemetry data about device
-			-D 'TNC_SELF_TELEMETRY_INTERVAL=1800000L' ; telemetry interval
+			-D 'TNC_SELF_TELEMETRY_INTERVAL=60000L' ; telemetry interval (milliseconds)
 
 [env:ttgo-t-beam-v1.0]
 platform = espressif32 @ 3.0.0

--- a/platformio.ini
+++ b/platformio.ini
@@ -53,6 +53,7 @@ build_flags =
 			-D 'FIX_BEACON_INTERVAL=1800000L'	; can be set from www interfeace
 			-D 'NETWORK_GPS_PORT=10110'			; GPS NMEA Port
 			-D 'ENABLE_TNC_SELF_TELEMETRY'		; send telemetry data about device
+			-D 'TNC_SELF_TELEMETRY_INTERVAL=1800000L' ; telemetry interval
 
 [env:ttgo-t-beam-v1.0]
 platform = espressif32 @ 3.0.0

--- a/src/TTGO_T-Beam_LoRa_APRS.ino
+++ b/src/TTGO_T-Beam_LoRa_APRS.ino
@@ -103,6 +103,7 @@ boolean key_up = true;
 boolean t_lock = false;
 boolean fixed_beacon_enabled = false;
 boolean show_cmt = true;
+int tel_interval;
 
 #ifdef SHOW_ALT
   boolean showAltitude = true;
@@ -139,7 +140,6 @@ String LatShown="";
 String LongFixed="";
 String LatFixed="";
 
-//#if (enable_tel == true) && defined(KISS_PROTOCOL)
 #if defined(ENABLE_TNC_SELF_TELEMETRY) && defined(KISS_PROTOCOL)
   time_t nextTelemetryFrame;
 #endif
@@ -485,7 +485,6 @@ String prepareCallsign(const String& callsign){
   return tmpString;
 }
 
-//#if (enable_tel == true) && defined(KISS_PROTOCOL)
 #if defined(ENABLE_TNC_SELF_TELEMETRY) && defined(KISS_PROTOCOL)
   void sendTelemetryFrame() {
     if(enable_tel == true){
@@ -527,6 +526,12 @@ void setup(){
   #else
     relay_path = "";
   #endif
+
+  //#ifdef TNC_SELF_TELEMETRY_INTERVAL
+  //  tel_interval = TNC_SELF_TELEMETRY_INTERVAL;
+  //#else
+  //  tel_interval = 60;
+  //#endif
 
   #ifdef FIXED_BEACON_EN
     fixed_beacon_enabled = true;
@@ -603,6 +608,12 @@ void setup(){
       preferences.putBool(PREF_ENABLE_TNC_SELF_TELEMETRY, enable_tel);
     }
     enable_tel = preferences.getBool(PREF_ENABLE_TNC_SELF_TELEMETRY);
+
+    if (!preferences.getBool(PREF_TNC_SELF_TELEMETRY_INTERVAL_INIT)){
+      preferences.putBool(PREF_TNC_SELF_TELEMETRY_INTERVAL_INIT, true);
+      preferences.putInt(PREF_TNC_SELF_TELEMETRY_INTERVAL, tel_interval);
+    }
+    tel_interval = preferences.getInt(PREF_TNC_SELF_TELEMETRY_INTERVAL);
 
     if (!preferences.getBool(PREF_APRS_LATITUDE_PRESET_INIT)){
       preferences.putBool(PREF_APRS_LATITUDE_PRESET_INIT, true);
@@ -1033,7 +1044,7 @@ void loop() {
   //#if (enable_tel == true) && defined(KISS_PROTOCOL)
   #if defined(ENABLE_TNC_SELF_TELEMETRY) && defined(KISS_PROTOCOL)
     if (nextTelemetryFrame < millis()){
-      nextTelemetryFrame = millis() + TNC_SELF_TELEMETRY_INTERVAL;
+      nextTelemetryFrame = millis() + (TNC_SELF_TELEMETRY_INTERVAL * 1000);
       sendTelemetryFrame();
     }
   #endif

--- a/src/TTGO_T-Beam_LoRa_APRS.ino
+++ b/src/TTGO_T-Beam_LoRa_APRS.ino
@@ -1044,7 +1044,7 @@ void loop() {
   //#if (enable_tel == true) && defined(KISS_PROTOCOL)
   #if defined(ENABLE_TNC_SELF_TELEMETRY) && defined(KISS_PROTOCOL)
     if (nextTelemetryFrame < millis()){
-      nextTelemetryFrame = millis() + (TNC_SELF_TELEMETRY_INTERVAL * 1000);
+      nextTelemetryFrame = millis() + (tel_interval * 1000);
       sendTelemetryFrame();
     }
   #endif

--- a/src/TTGO_T-Beam_LoRa_APRS.ino
+++ b/src/TTGO_T-Beam_LoRa_APRS.ino
@@ -103,8 +103,6 @@ boolean key_up = true;
 boolean t_lock = false;
 boolean fixed_beacon_enabled = false;
 boolean show_cmt = true;
-// Telemetry interval, seconds
-int tel_interval;
 // Telemetry sequence, current value
 int tel_sequence;
 
@@ -122,6 +120,12 @@ int tel_sequence;
   boolean enable_tel = true;
 #else
   boolean enable_tel = false;
+#endif
+  // Telemetry interval, seconds
+#ifdef TNC_SELF_TELEMETRY_INTERVAL
+  int tel_interval = TNC_SELF_TELEMETRY_INTERVAL;
+#else
+  int tel_interval = 3600;
 #endif
 #ifdef TNC_SELF_TELEMETRY_MIC
   int tel_mic = 1; // telemetry as "T#MIC"
@@ -557,7 +561,11 @@ String prepareCallsign(const String& callsign){
         #endif
 
         // Update the telemetry sequence number
-        tel_sequence = tel_sequence + 1;
+        if(tel_sequence >= 999){
+          tel_sequence = 0;
+        }else{
+          tel_sequence = tel_sequence + 1;
+        }
         preferences.putUInt(PREF_TNC_SELF_TELEMETRY_SEQ, tel_sequence);
           
     }

--- a/src/TTGO_T-Beam_LoRa_APRS.ino
+++ b/src/TTGO_T-Beam_LoRa_APRS.ino
@@ -494,11 +494,15 @@ String prepareCallsign(const String& callsign){
         uint8_t b_out_c = (axp.getBattDischargeCurrent()) / 10;
         uint8_t ac_volt = (axp.getVbusVoltage() - 3000) / 28;
         uint8_t ac_c = (axp.getVbusCurrent()) / 10;
+        // Pad telemetry message address to 9 characters
+        char Tcall_message_char[9];
+        sprintf_P(Tcall_message_char, "%-9s", Tcall);
+        String Tcall_message = String(Tcall_message_char);
 
-        String telemetryParamsNames = String(":") + Tcall + ":PARM.B Volt,B In,B Out,AC V,AC C";
-        String telemetryUnitNames = String(":") + Tcall + ":UNIT.mV,mA,mA,mV,mA";
-        String telemetryEquations = String(":") + Tcall + ":EQNS.0,5.1,3000,0,10,0,0,10,0,0,28,3000,0,10,0";
-        String telemetryData = String("T#MIC") + String(b_volt) + ","+ String(b_in_c) + ","+ String(b_out_c) + ","+ String(ac_volt) + ","+ String(ac_c) + ",00000000";
+        String telemetryParamsNames = String(":") + Tcall_message + ":PARM.B Volt,B In,B Out,AC V,AC C";
+        String telemetryUnitNames = String(":") + Tcall_message + ":UNIT.mV,mA,mA,mV,mA";
+        String telemetryEquations = String(":") + Tcall_message + ":EQNS.0,5.1,3000,0,10,0,0,10,0,0,28,3000,0,10,0";
+        String telemetryData = String("T#") + String(b_volt) + ","+ String(b_in_c) + ","+ String(b_out_c) + ","+ String(ac_volt) + ","+ String(ac_c) + ",00000000";
         String telemetryBase = "";
         telemetryBase += Tcall + ">APLO01," + relay_path + ":";
         Serial.print(telemetryBase);

--- a/src/TTGO_T-Beam_LoRa_APRS.ino
+++ b/src/TTGO_T-Beam_LoRa_APRS.ino
@@ -123,6 +123,11 @@ int tel_sequence;
 #else
   boolean enable_tel = false;
 #endif
+#ifdef TNC_SELF_TELEMETRY_MIC
+  int tel_mic = 1; // telemetry as "T#MIC"
+#else
+  int tel_mic = 0; // telemetry as "T#001"
+#endif
 #ifdef ENABLE_BLUETOOTH
   boolean enable_bluetooth = true;
 #else
@@ -519,11 +524,17 @@ String prepareCallsign(const String& callsign){
         #endif
 
         // Determine sequence number (or 'MIC')
-        tel_sequence = preferences.getUInt(PREF_TNC_SELF_TELEMETRY_SEQ, 0);
-        // Pad to 3 digits
-        char tel_sequence_char[3];
-        sprintf_P(tel_sequence_char, "%03u", tel_sequence);
-        String tel_sequence_str = String(tel_sequence_char);
+        String tel_sequence_str;
+        if(tel_mic == 1){
+          tel_sequence_str = "MIC";
+        }else{
+          // Get the current saved telemetry sequence
+          tel_sequence = preferences.getUInt(PREF_TNC_SELF_TELEMETRY_SEQ, 0);
+          // Pad to 3 digits
+          char tel_sequence_char[3];
+          sprintf_P(tel_sequence_char, "%03u", tel_sequence);
+          tel_sequence_str = String(tel_sequence_char);
+        }
         
         String telemetryParamsNames = String(":") + Tcall_message + ":PARM.B Volt,B In,B Out,AC V,AC C";
         String telemetryUnitNames = String(":") + Tcall_message + ":UNIT.mV,mA,mA,mV,mA";
@@ -668,6 +679,12 @@ void setup(){
       preferences.putInt(PREF_TNC_SELF_TELEMETRY_SEQ, tel_sequence);
     }
     tel_sequence = preferences.getInt(PREF_TNC_SELF_TELEMETRY_SEQ);
+
+    if (!preferences.getBool(PREF_TNC_SELF_TELEMETRY_MIC_INIT)){
+      preferences.putBool(PREF_TNC_SELF_TELEMETRY_MIC_INIT, true);
+      preferences.putInt(PREF_TNC_SELF_TELEMETRY_MIC, tel_mic);
+    }
+    tel_mic = preferences.getInt(PREF_TNC_SELF_TELEMETRY_MIC);
 
     if (!preferences.getBool(PREF_APRS_LATITUDE_PRESET_INIT)){
       preferences.putBool(PREF_APRS_LATITUDE_PRESET_INIT, true);

--- a/src/TTGO_T-Beam_LoRa_APRS.ino
+++ b/src/TTGO_T-Beam_LoRa_APRS.ino
@@ -511,6 +511,10 @@ String prepareCallsign(const String& callsign){
         char Tcall_message_char[9];
         sprintf_P(Tcall_message_char, "%-9s", Tcall);
         String Tcall_message = String(Tcall_message_char);
+        // Flash the light when telemetry is being sent
+        #ifdef ENABLE_LED_SIGNALING
+          digitalWrite(TXLED, LOW);
+        #endif
 
         // Determine sequence number (or 'MIC')
         // Pad to 3 digits
@@ -534,7 +538,9 @@ String prepareCallsign(const String& callsign){
         writedisplaytext("((TEL TX))","","","","","");
 
         // Flash the light when telemetry is being sent
-        // CODE HERE
+        #ifdef ENABLE_LED_SIGNALING
+          digitalWrite(TXLED, HIGH);
+        #endif
 
         // Update the telemetry sequence number
         if(tel_sequence >= 0 & tel_sequence < 999){
@@ -1136,7 +1142,6 @@ void loop() {
       }
     }
   }
-  //#if (enable_tel == true) && defined(KISS_PROTOCOL)
   #if defined(ENABLE_TNC_SELF_TELEMETRY) && defined(KISS_PROTOCOL)
     if (nextTelemetryFrame < millis()){
       nextTelemetryFrame = millis() + (tel_interval * 1000);

--- a/src/TTGO_T-Beam_LoRa_APRS.ino
+++ b/src/TTGO_T-Beam_LoRa_APRS.ino
@@ -107,7 +107,6 @@ boolean show_cmt = true;
 int tel_interval;
 // Telemetry sequence, current value
 int tel_sequence;
-//int tel_sequence = preferences.getInt(PREF_TNC_SELF_TELEMETRY_SEQ, 0);
 
 #ifdef SHOW_ALT
   boolean showAltitude = true;
@@ -124,11 +123,6 @@ int tel_sequence;
 #else
   boolean enable_tel = false;
 #endif
-//#ifdef TNC_SELF_TELEMETRY_SEQ
-//  int tel_sequence = TNC_SELF_TELEMETRY_SEQ;
-//#else
-//  int tel_sequence = PREF_TNC_SELF_TELEMETRY_SEQ;
-//#endif
 #ifdef ENABLE_BLUETOOTH
   boolean enable_bluetooth = true;
 #else
@@ -552,13 +546,8 @@ String prepareCallsign(const String& callsign){
         #endif
 
         // Update the telemetry sequence number
-        //if(tel_sequence >= 0 & tel_sequence < 999){
-          tel_sequence = tel_sequence + 1;
-          //} 
-          //else {
-          //  tel_sequence = 0;
-          //}
-          preferences.putUInt(PREF_TNC_SELF_TELEMETRY_SEQ, tel_sequence);
+        tel_sequence = tel_sequence + 1;
+        preferences.putUInt(PREF_TNC_SELF_TELEMETRY_SEQ, tel_sequence);
           
     }
     #endif

--- a/src/TTGO_T-Beam_LoRa_APRS.ino
+++ b/src/TTGO_T-Beam_LoRa_APRS.ino
@@ -500,7 +500,8 @@ String prepareCallsign(const String& callsign){
         String telemetryEquations = String(":") + Tcall + ":EQNS.0,5.1,3000,0,10,0,0,10,0,0,28,3000,0,10,0";
         String telemetryData = String("T#MIC") + String(b_volt) + ","+ String(b_in_c) + ","+ String(b_out_c) + ","+ String(ac_volt) + ","+ String(ac_c) + ",00000000";
         String telemetryBase = "";
-        telemetryBase += Tcall + ">APLO01" + ":";
+        telemetryBase += Tcall + ">APLO01," + relay_path + ":";
+        Serial.print(telemetryBase);
         sendToTNC(telemetryBase + telemetryParamsNames);
         sendToTNC(telemetryBase + telemetryUnitNames);
         sendToTNC(telemetryBase + telemetryEquations);

--- a/src/taskWebServer.cpp
+++ b/src/taskWebServer.cpp
@@ -272,6 +272,12 @@ void handle_SaveAPRSCfg() {
   if (server.hasArg(PREF_APRS_LONGITUDE_PRESET)){
     preferences.putString(PREF_APRS_LONGITUDE_PRESET, server.arg(PREF_APRS_LONGITUDE_PRESET));
   }
+  if (server.hasArg(PREF_TNC_SELF_TELEMETRY_INTERVAL)){
+    preferences.putInt(PREF_TNC_SELF_TELEMETRY_INTERVAL, server.arg(PREF_TNC_SELF_TELEMETRY_INTERVAL).toInt());
+  }
+//Arg(PREF_TNC_SELF_TELEMETRY_SEQ)){
+ //   preferences.putInt(PREF_TNC_SELF_TELEMETRY_SEQ, server.arg(PREF_TNC_SELF_TELEMETRY_SEQ).toInt());
+  //}
 
   // Smart Beaconing settings 
   if (server.hasArg(PREF_APRS_FIXED_BEACON_INTERVAL_PRESET)){
@@ -292,9 +298,7 @@ void handle_SaveAPRSCfg() {
   if (server.hasArg(PREF_APRS_SB_ANGLE_PRESET)){
     preferences.putDouble(PREF_APRS_SB_ANGLE_PRESET, server.arg(PREF_APRS_SB_ANGLE_PRESET).toDouble());
   }
-  if (server.hasArg(PREF_TNC_SELF_TELEMETRY_INTERVAL)){
-    preferences.putInt(PREF_TNC_SELF_TELEMETRY_INTERVAL, server.arg(PREF_TNC_SELF_TELEMETRY_INTERVAL).toInt());
-  }
+  
 
   preferences.putBool(PREF_APRS_SHOW_BATTERY, server.hasArg(PREF_APRS_SHOW_BATTERY));
   preferences.putBool(PREF_ENABLE_TNC_SELF_TELEMETRY, server.hasArg(PREF_ENABLE_TNC_SELF_TELEMETRY));

--- a/src/taskWebServer.cpp
+++ b/src/taskWebServer.cpp
@@ -206,6 +206,7 @@ void handle_Cfg() {
   jsonData += jsonLineFromPreferenceBool(PREF_APRS_GPS_EN);
   jsonData += jsonLineFromPreferenceBool(PREF_ENABLE_TNC_SELF_TELEMETRY);
   jsonData += jsonLineFromPreferenceInt(PREF_TNC_SELF_TELEMETRY_INTERVAL);
+  jsonData += jsonLineFromPreferenceInt(PREF_TNC_SELF_TELEMETRY_MIC);
   jsonData += jsonLineFromPreferenceBool(PREF_DEV_OL_EN);
   jsonData += jsonLineFromPreferenceBool(PREF_APRS_SHOW_CMT);
   jsonData += jsonLineFromPreferenceBool(PREF_DEV_BT_EN);
@@ -274,6 +275,9 @@ void handle_SaveAPRSCfg() {
   }
   if (server.hasArg(PREF_TNC_SELF_TELEMETRY_INTERVAL)){
     preferences.putInt(PREF_TNC_SELF_TELEMETRY_INTERVAL, server.arg(PREF_TNC_SELF_TELEMETRY_INTERVAL).toInt());
+  }
+  if (server.hasArg(PREF_TNC_SELF_TELEMETRY_MIC)){
+    preferences.putInt(PREF_TNC_SELF_TELEMETRY_MIC, server.arg(PREF_TNC_SELF_TELEMETRY_MIC).toInt());
   }
 
   // Smart Beaconing settings 

--- a/src/taskWebServer.cpp
+++ b/src/taskWebServer.cpp
@@ -275,9 +275,6 @@ void handle_SaveAPRSCfg() {
   if (server.hasArg(PREF_TNC_SELF_TELEMETRY_INTERVAL)){
     preferences.putInt(PREF_TNC_SELF_TELEMETRY_INTERVAL, server.arg(PREF_TNC_SELF_TELEMETRY_INTERVAL).toInt());
   }
-//Arg(PREF_TNC_SELF_TELEMETRY_SEQ)){
- //   preferences.putInt(PREF_TNC_SELF_TELEMETRY_SEQ, server.arg(PREF_TNC_SELF_TELEMETRY_SEQ).toInt());
-  //}
 
   // Smart Beaconing settings 
   if (server.hasArg(PREF_APRS_FIXED_BEACON_INTERVAL_PRESET)){

--- a/src/taskWebServer.cpp
+++ b/src/taskWebServer.cpp
@@ -172,6 +172,7 @@ void handle_Cfg() {
   jsonData += jsonLineFromPreferenceBool(PREF_APRS_SHOW_ALTITUDE);
   jsonData += jsonLineFromPreferenceBool(PREF_APRS_GPS_EN);
   jsonData += jsonLineFromPreferenceBool(PREF_ENABLE_TNC_SELF_TELEMETRY);
+  jsonData += jsonLineFromPreferenceInt(PREF_TNC_SELF_TELEMETRY_INTERVAL);
   jsonData += jsonLineFromPreferenceBool(PREF_DEV_OL_EN);
   jsonData += jsonLineFromPreferenceBool(PREF_APRS_SHOW_CMT);
   jsonData += jsonLineFromPreferenceBool(PREF_DEV_BT_EN);
@@ -255,6 +256,9 @@ void handle_SaveAPRSCfg() {
   }
   if (server.hasArg(PREF_APRS_SB_ANGLE_PRESET)){
     preferences.putDouble(PREF_APRS_SB_ANGLE_PRESET, server.arg(PREF_APRS_SB_ANGLE_PRESET).toDouble());
+  }
+  if (server.hasArg(PREF_TNC_SELF_TELEMETRY_INTERVAL)){
+    preferences.putInt(PREF_TNC_SELF_TELEMETRY_INTERVAL, server.arg(PREF_TNC_SELF_TELEMETRY_INTERVAL).toInt());
   }
 
   preferences.putBool(PREF_APRS_SHOW_BATTERY, server.hasArg(PREF_APRS_SHOW_BATTERY));

--- a/src/taskWebServer.cpp
+++ b/src/taskWebServer.cpp
@@ -171,6 +171,7 @@ void handle_Cfg() {
   jsonData += jsonLineFromPreferenceBool(PREF_APRS_FIXED_BEACON_PRESET);
   jsonData += jsonLineFromPreferenceBool(PREF_APRS_SHOW_ALTITUDE);
   jsonData += jsonLineFromPreferenceBool(PREF_APRS_GPS_EN);
+  jsonData += jsonLineFromPreferenceBool(PREF_ENABLE_TNC_SELF_TELEMETRY);
   jsonData += jsonLineFromPreferenceBool(PREF_DEV_OL_EN);
   jsonData += jsonLineFromPreferenceBool(PREF_APRS_SHOW_CMT);
   jsonData += jsonLineFromPreferenceBool(PREF_DEV_BT_EN);
@@ -257,6 +258,7 @@ void handle_SaveAPRSCfg() {
   }
 
   preferences.putBool(PREF_APRS_SHOW_BATTERY, server.hasArg(PREF_APRS_SHOW_BATTERY));
+  preferences.putBool(PREF_ENABLE_TNC_SELF_TELEMETRY, server.hasArg(PREF_ENABLE_TNC_SELF_TELEMETRY));
   preferences.putBool(PREF_APRS_SHOW_ALTITUDE, server.hasArg(PREF_APRS_SHOW_ALTITUDE));
   preferences.putBool(PREF_APRS_FIXED_BEACON_PRESET, server.hasArg(PREF_APRS_FIXED_BEACON_PRESET));
   preferences.putBool(PREF_APRS_GPS_EN, server.hasArg(PREF_APRS_GPS_EN));


### PR DESCRIPTION
TTGO T-beam v.1.0 changes only.

The point of this is to clean up the telemetry information and give some control over it from the www interface. See also #59. Added numeric telemetry sequence rather than MIC by default.

- [x] telementry enable in www
- [x] telemetry interval in www
- [x] add www option for `MIC` telemetry rather than sequence
- [x] bug: sequence is not getting saved between reboots
- [x] notify when sending telemetry (blink and/or screen)
     - [x] screen
     - [x] flash LED
- [x] work with IS websites?
    - [x] aprs.fi (with T# sequence, not MIC)
    - [x] aprsdirect.com (with T# sequence, not MIC)
    - [x] do they show the same data?

Potential future work (not in this PR):
- choose which self telemetry values to send in www
- allow separate telemetry path in www

~~I will fill this in from my work at https://github.com/mattbk/TTGO-T-Beam-LoRa-APRS/pull/2, I didn't make the PR right in the first place.~~
