### PR TITLE
GPS TCP: fix compilation without WiFi

### DIFF
--- a/src/taskGPS.cpp
+++ b/src/taskGPS.cpp
@@ -45,7 +45,9 @@ bool gpsInitialized = false;
 
   String gpsDataBuffer = "              ";
   for (;;) {
+    #ifdef ENABLE_WIFI
     check_for_new_clients(&gpsServer, gps_clients, MAX_GPS_WIFI_CLIENTS);
+    #endif
     while (gpsSerial.available() > 0) {
       char gpsChar = (char)gpsSerial.read();
       gps.encode(gpsChar);


### PR DESCRIPTION
This adds an ifdef around a wifi-specific line introduced in
edee67e7980d2d62f82d2ee98a77ab53ef955940.